### PR TITLE
fix: use local space for camera pan

### DIFF
--- a/src/OrbitCamera.cs
+++ b/src/OrbitCamera.cs
@@ -71,8 +71,9 @@ public partial class OrbitCamera : Node3D
             _cameraPitch += pitch;
         } else if (_panning)
         {
-            var offset = new Vector3(-_mouseMotion.X, _mouseMotion.Y, 0) * PanSensitivity;
-            Position = Position.Lerp(Position + offset, LerpSpeed * (float)delta);
+            var targetOffset = new Vector3(-_mouseMotion.X, _mouseMotion.Y, 0) * PanSensitivity;
+            var offset = Vector3.Zero.Lerp(targetOffset, LerpSpeed * (float)delta);
+            TranslateObjectLocal(offset);
         }
 
         _mouseMotion = Vector2.Zero;


### PR DESCRIPTION
Camera was panning relative to the parent node, rather than relative to the camera's rotation.