### PR TITLE
fix: make line renderer properties init only

### DIFF
--- a/src/Render/LineRenderer.cs
+++ b/src/Render/LineRenderer.cs
@@ -6,8 +6,8 @@ namespace KeepersCompound.ModelEditor.Render;
 
 public partial class LineRenderer : Node3D
 {
-    public List<Vector3> Vertices { get; set; } = [];
-    public Color LineColor { get; set; } = Colors.White;
+    public List<Vector3> Vertices { get; init; } = [];
+    public Color LineColor { get; init; } = Colors.White;
 
     #region Godot Overrides
 


### PR DESCRIPTION
Being used correctly everywhere right now, but this fixes potential issues with the properties being modified and not reflected in the rendered mesh. This might get changed in the future back to being `set;` and adding a `Rebuild` method.